### PR TITLE
Fix for Firefox - event.toElement is undefined, instead use event.target

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,9 +8,9 @@
     <script type="text/javascript" src="js/vendor/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.css">
     <link rel="stylesheet" href="css/default.css" type="text/css"/>
-    <link rel="icon"
-          type="image/png"
-          href="./favicon.png">
+    <link rel="icon" type="image/png" href="./favicon.png">
+    <link rel="manifest" href="/manifest.json">
+
 </head>
 <body>
 <template id="historySongTemplate">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "short_name": "EDMRadio",
+  "name": "EDM Radio Haritz Medina",
+  "icons": [
+    {
+      "src": "favicon.png",
+      "type": "image/png",
+      "sizes": "128x128"
+    }
+  ],
+  "start_url": "index.php"
+}


### PR DESCRIPTION
Hi, thanks for the useful, simple and nice radio player. I have noticed a bug, when you enter the radio page on Firefox it doesn't work, because event.toElement is undefined. To fix it, replace the event.toElement with event.target and then it works on both Chrome and Firefox. Thanks

Here is my updated code:

`    function addEventListener(listenButton) {
       listenButton.addEventListener("click", function (event) {
           // Get clicked radio
           var currentStation = document.getElementById('audioPlayer').dataset.station || '';
           var newStation = event.target;
           if (newStation !== currentStation) {
               // Get selected radio media URI
               var radioUri = newStation.dataset.radioUri;
               // Get player
               var player = document.getElementById('audioPlayer');
               // Set new radio to the player
               player.innerHTML = "<source id='sourcePL' src='" + radioUri + "' type='audio/mpeg'/>";
               player.dataset.station = newStation.innerText;
               // Reload and play
               player.load();
               playPlayer();
               // Set to select current radio
               selectRadio(newStation);
               ga('send', 'event', 'listenRadio', 'radioStation', newStation);
           }
       });
    }`